### PR TITLE
fix(package): add version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "validate-commit-msg",
   "description": "Script to validate a commit message follows the conventional changelog standard",
   "main": "index.js",
+  "version": "0.0.0-development",
   "scripts": {
     "commit": "git-cz",
     "check-coverage": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",


### PR DESCRIPTION
Without a version entry in package.json a npm install via git URL fails

```
npm i https://github.com/kentcdodds/validate-commit-msg.git
npm ERR! addLocal Could not install [...]
npm ERR! No version provided in package.json
```

