### PR TITLE
Make commit matching pattern more true to the spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var semverRegex = require('semver-regex')
 
 var config = getConfig();
 var MAX_LENGTH = config.maxSubjectLength || 100;
-var PATTERN = /^((?:fixup!\s*)?(\w*)(\(([\w\$\.\*/-]*)\))?\: (.*))(\n|$)/;
+var PATTERN = /^((\w+)(?:\(([^\)\s]+)\))?: (.+))(?:\n|$)/;
 var IGNORED = new RegExp(util.format('(^WIP)|(^%s$)', semverRegex().source));
 var TYPES = config.types || ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'chore', 'revert'];
 
@@ -47,8 +47,8 @@ var validateMessage = function(message) {
   } else {
     var firstLine = match[1];
     var type = match[2];
-    var scope = match[4];
-    var subject = match[5];
+    var scope = match[3];
+    var subject = match[4];
 
     if (firstLine.length > MAX_LENGTH) {
       error('is longer than %d characters !', MAX_LENGTH);

--- a/index.test.js
+++ b/index.test.js
@@ -35,19 +35,20 @@ describe('validate-commit-msg.js', function() {
   describe('validateMessage', function() {
 
     it('should be valid', function() {
-      expect(m.validateMessage('fixup! fix($compile): something')).to.equal(VALID);
-      expect(m.validateMessage('fix($compile): something')).to.equal(VALID);
-      expect(m.validateMessage('feat($location): something')).to.equal(VALID);
-      expect(m.validateMessage('docs($filter): something')).to.equal(VALID);
-      expect(m.validateMessage('style($http): something')).to.equal(VALID);
-      expect(m.validateMessage('refactor($httpBackend): something')).to.equal(VALID);
-      expect(m.validateMessage('test($resource): something')).to.equal(VALID);
       expect(m.validateMessage('chore($controller): something')).to.equal(VALID);
-      expect(m.validateMessage('chore(foo-bar): something')).to.equal(VALID);
       expect(m.validateMessage('chore(*): something')).to.equal(VALID);
+      expect(m.validateMessage('chore(foo-bar): something')).to.equal(VALID);
       expect(m.validateMessage('chore(guide/location): something')).to.equal(VALID);
-      expect(m.validateMessage('revert(foo): something')).to.equal(VALID);
       expect(m.validateMessage('custom(baz): something')).to.equal(VALID);
+      expect(m.validateMessage('docs($filter): something')).to.equal(VALID);
+      expect(m.validateMessage('feat($location): something (another thing)')).to.equal(VALID);
+      expect(m.validateMessage('fix($compile): something')).to.equal(VALID);
+      expect(m.validateMessage('refactor($httpBackend): something')).to.equal(VALID);
+      expect(m.validateMessage('revert(foo): something')).to.equal(VALID);
+      expect(m.validateMessage('revert: feat($location): something')).to.equal(VALID);
+      expect(m.validateMessage('style($http): something')).to.equal(VALID);
+      expect(m.validateMessage('test($resource): something')).to.equal(VALID);
+
       expect(errors).to.deep.equal([]);
       expect(logs).to.deep.equal([]);
     });
@@ -115,9 +116,16 @@ describe('validate-commit-msg.js', function() {
       expect(logs).to.not.deep.equal([]);
     });
 
+
+    it('should not allow msg prefixed with "fixup!"', function() {
+      expect(m.validateMessage('fixup! fix($compile): something')).to.equal(INVALID);
+    });
+
+
     it('should handle undefined message"', function() {
       expect(m.validateMessage()).to.equal(INVALID);
     });
+
 
     it('should allow semver style commits', function() {
       expect(m.validateMessage('v1.0.0-alpha.1')).to.equal(VALID);
@@ -129,4 +137,3 @@ describe('validate-commit-msg.js', function() {
     console.error = originalError;
   });
 });
-


### PR DESCRIPTION
This PR makes the commit message matching regular expression pattern more true to the spec by:                                                                    

* removing `fixup! ` as an allowed message prefix
* allowing any character except `)` and white space as scope name
* require a commit message subject
* removing unused pattern matching groups

**Before:**

<img width="959" alt="screen shot 2015-10-18 at 23 03 06" src="https://cloud.githubusercontent.com/assets/968267/10566674/0f7d27a6-75ee-11e5-8e36-da24a07578b8.png">

**After:**

<img width="781" alt="screen shot 2016-02-05 at 12 40 22" src="https://cloud.githubusercontent.com/assets/968267/12845388/b333964c-cc05-11e5-95fa-b842a899aed2.png">

Signed-off-by: Hans Kristian Flaatten <hans@starefossen.com>