### PR TITLE
fix(robustness): handle undefined message buffer, closes #9

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,10 @@ if (process.argv.join('').indexOf('mocha') === -1) {
   var commitMsgFile = process.argv[2] || './.git/COMMIT_EDITMSG';
   var incorrectLogFile = commitMsgFile.replace('COMMIT_EDITMSG', 'logs/incorrect-commit-msgs');
 
+  var hasToString = function hasToString(x) {
+    return x && typeof x.toString === 'function';
+  };
+
   fs.readFile(commitMsgFile, function(err, buffer) {
     var msg = firstLineFromBuffer(buffer);
 
@@ -105,7 +109,7 @@ if (process.argv.join('').indexOf('mocha') === -1) {
     }
 
     function firstLineFromBuffer(buffer) {
-      return buffer.toString().split('\n').shift();
+      return hasToString(buffer) && buffer.toString().split('\n').shift();
     }
   });
 }

--- a/index.test.js
+++ b/index.test.js
@@ -99,6 +99,11 @@ describe('validate-commit-msg.js', function() {
     it('should ignore msg prefixed with "WIP: "', function() {
       expect(m.validateMessage('WIP: bullshit')).to.equal(VALID);
     });
+
+
+    it('should handle undefined message"', function() {
+      expect(m.validateMessage()).to.equal(INVALID);
+    });
   });
 
   afterEach(function() {


### PR DESCRIPTION
should protect when called without an actual message