### PR TITLE
feat(validateMessage): display original message when it is not valid

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,11 +105,6 @@ if (process.argv.join('').indexOf('mocha') === -1) {
   });
 }
 
-function getTypes() {
-  var defaultTypes = ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'chore', 'revert'];
-  return config.types || defaultTypes;
-}
-
 function getConfig() {
   var pkgFile = findup.sync(process.cwd(), 'package.json');
   var pkg = JSON.parse(fs.readFileSync(resolve(pkgFile, 'package.json')));

--- a/index.js
+++ b/index.js
@@ -41,23 +41,23 @@ var validateMessage = function(message) {
   var match = PATTERN.exec(message);
 
   if (!match) {
-    error('does not match "<type>(<scope>): <subject>" ! was: ' + message);
-    return failure();
-  }
-
-  var firstLine = match[1];
-  var type = match[2];
-  var scope = match[4];
-  var subject = match[5];
-
-  if (firstLine.length > MAX_LENGTH) {
-    error('is longer than %d characters !', MAX_LENGTH);
+    error('does not match "<type>(<scope>): <subject>" !');
     isValid = false;
-  }
+  } else {
+    var firstLine = match[1];
+    var type = match[2];
+    var scope = match[4];
+    var subject = match[5];
 
-  if (TYPES !== '*' && TYPES.indexOf(type) === -1) {
-    error('"%s" is not allowed type !', type);
-    return failure();
+    if (firstLine.length > MAX_LENGTH) {
+      error('is longer than %d characters !', MAX_LENGTH);
+      isValid = false;
+    }
+
+    if (TYPES !== '*' && TYPES.indexOf(type) === -1) {
+      error('"%s" is not allowed type !', type);
+      isValid = false;
+    }
   }
 
   // Some more ideas, do want anything like this ?
@@ -70,11 +70,14 @@ var validateMessage = function(message) {
   // - auto correct typos in type ?
   // - store incorrect messages, so that we can learn
 
-  return isValid ? true : failure();
+  isValid = isValid || config.warnOnFail;
 
-  function failure() {
-    return config.warnOnFail ? true : false;
+  // Display original message when it is not valid, otherwise it will be lost
+  if (!isValid && message) {
+    console.log(message);
   }
+
+  return isValid;
 };
 
 

--- a/index.test.js
+++ b/index.test.js
@@ -49,14 +49,16 @@ describe('validate-commit-msg.js', function() {
       expect(m.validateMessage('revert(foo): something')).to.equal(VALID);
       expect(m.validateMessage('custom(baz): something')).to.equal(VALID);
       expect(errors).to.deep.equal([]);
+      expect(logs).to.deep.equal([]);
     });
 
 
     it('should validate 100 characters length', function() {
-      var msg = "fix($compile): something super mega extra giga tera long, maybe even longer and longer and longer... ";
+      var msg = 'fix($compile): something super mega extra giga tera long, maybe even longer and longer and longer... ';
 
       expect(m.validateMessage(msg)).to.equal(INVALID);
       expect(errors).to.deep.equal(['INVALID COMMIT MSG: is longer than 100 characters !']);
+      expect(logs).to.deep.equal([msg]);
     });
 
     it('should work fine with a bigger body', function() {
@@ -68,8 +70,10 @@ describe('validate-commit-msg.js', function() {
         'Closes #14',
         'BREAKING CHANGE: Something is totally broken :-('
       ].join('\n');
+
       expect(m.validateMessage(message)).to.equal(VALID);
       expect(errors).to.deep.equal([]);
+      expect(logs).to.deep.equal([]);
     });
 
 
@@ -77,28 +81,38 @@ describe('validate-commit-msg.js', function() {
       var msg = 'not correct format';
 
       expect(m.validateMessage(msg)).to.equal(INVALID);
-      expect(errors).to.deep.equal(['INVALID COMMIT MSG: does not match "<type>(<scope>): <subject>" ! was: not correct format']);
+      expect(errors).to.deep.equal(['INVALID COMMIT MSG: does not match "<type>(<scope>): <subject>" !']);
+      expect(logs).to.deep.equal([msg]);
     });
 
 
     it('should validate type', function() {
-      expect(m.validateMessage('weird($filter): something')).to.equal(INVALID);
+      var msg = 'weird($filter): something';
+
+      expect(m.validateMessage(msg)).to.equal(INVALID);
       expect(errors).to.deep.equal(['INVALID COMMIT MSG: "weird" is not allowed type !']);
+      expect(logs).to.deep.equal([msg]);
     });
 
 
     it('should allow empty scope', function() {
       expect(m.validateMessage('fix: blablabla')).to.equal(VALID);
+      expect(errors).to.deep.equal([]);
+      expect(logs).to.deep.equal([]);
     });
 
 
     it('should allow dot in scope', function() {
       expect(m.validateMessage('chore(mocks.$httpBackend): something')).to.equal(VALID);
+      expect(errors).to.deep.equal([]);
+      expect(logs).to.deep.equal([]);
     });
 
 
     it('should ignore msg prefixed with "WIP "', function() {
       expect(m.validateMessage('WIP stuff')).to.equal(VALID);
+      expect(errors).to.deep.equal([]);
+      expect(logs).to.not.deep.equal([]);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "commit": "git-cz",
-    "check-coverage": "istanbul check-coverage --statements 96 --branches 81 --functions 87 --lines 96",
+    "check-coverage": "istanbul check-coverage --statements 100 --branches 90 --functions 100 --lines 100",
     "report-coverage": "cat ./coverage/lcov.info | codecov",
     "test:watch": "istanbul cover -x *.test.js _mocha -- -R spec -w index.test.js",
     "test": "istanbul cover -x *.test.js _mocha -- -R spec index.test.js",


### PR DESCRIPTION
Really helpfull to not have to rewrite everything. It happened to me because I went over the 100 chars limit... :-)

It will change this output :
```
INVALID COMMIT MSG: is longer than 100 characters !
```
to :
```
INVALID COMMIT MSG: is longer than 100 characters !
feat(superCoolScopeDesignedToBeSpeciallyLong): talk about this super cool feature, but talking about it too much making it exceed the length limit
```