### PR TITLE
fix(WIP): Remove `:` from WIP

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var findup = require('findup');
 var config = getConfig();
 var MAX_LENGTH = config.maxSubjectLength || 100;
 var PATTERN = /^((?:fixup!\s*)?(\w*)(\(([\w\$\.\*/-]*)\))?\: (.*))(\n|$)/;
-var IGNORED = /^WIP\:/;
+var IGNORED = /^WIP/;
 var TYPES = config.types || ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'chore', 'revert'];
 
 var error = function() {


### PR DESCRIPTION
Love that you have this pattern in here, I was just about to add it.

I find myself frequently using `WIP` for placeholders. I almost never include the colon. 
When typing a quick `WIP` commit message, it's easier / faster to omit the colon. I think it makes sense to be less stringent on the ignore use case.

Thoughts?
