### PR TITLE
feat(validateMessage): Allow semver commits

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,11 +15,12 @@ var fs = require('fs');
 var util = require('util');
 var resolve = require('path').resolve;
 var findup = require('findup');
+var semverRegex = require('semver-regex')
 
 var config = getConfig();
 var MAX_LENGTH = config.maxSubjectLength || 100;
 var PATTERN = /^((?:fixup!\s*)?(\w*)(\(([\w\$\.\*/-]*)\))?\: (.*))(\n|$)/;
-var IGNORED = /^WIP/;
+var IGNORED = new RegExp(util.format('(^WIP)|(^%s$)', semverRegex().source));
 var TYPES = config.types || ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'chore', 'revert'];
 
 var error = function() {

--- a/index.test.js
+++ b/index.test.js
@@ -101,9 +101,12 @@ describe('validate-commit-msg.js', function() {
       expect(m.validateMessage('WIP stuff')).to.equal(VALID);
     });
 
-
     it('should handle undefined message"', function() {
       expect(m.validateMessage()).to.equal(INVALID);
+    });
+
+    it('should allow semver style commits', function() {
+      expect(m.validateMessage('v1.0.0-alpha.1')).to.equal(VALID);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     }
   },
   "dependencies": {
-    "findup": "0.1.5"
+    "findup": "0.1.5",
+    "semver-regex": "1.0.0"
   }
 }


### PR DESCRIPTION
In this PR the `IGNORED` regular expression is updated to skip commits that contain just a valid semver as the ones generated by `npm version`.

Closes #13 