### PR TITLE
feat: allow fixup! and squash!

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,11 @@ var semverRegex = require('semver-regex')
 
 var config = getConfig();
 var MAX_LENGTH = config.maxSubjectLength || 100;
-var PATTERN = /^((\w+)(?:\(([^\)\s]+)\))?: (.+))(?:\n|$)/;
 var IGNORED = new RegExp(util.format('(^WIP)|(^%s$)', semverRegex().source));
 var TYPES = config.types || ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'chore', 'revert'];
+
+// fixup! and squash! are part of Git, commits tagged with them are not intended to be merged, cf. https://git-scm.com/docs/git-commit
+var PATTERN = /^((fixup! |squash! )?(\w+)(?:\(([^\)\s]+)\))?: (.+))(?:\n|$)/;
 
 var error = function() {
   // gitx does not display it
@@ -46,11 +48,12 @@ var validateMessage = function(message) {
     isValid = false;
   } else {
     var firstLine = match[1];
-    var type = match[2];
-    var scope = match[3];
-    var subject = match[4];
+    var squashing = !!match[2];
+    var type = match[3];
+    var scope = match[4];
+    var subject = match[5];
 
-    if (firstLine.length > MAX_LENGTH) {
+    if (firstLine.length > MAX_LENGTH && !squashing) {
       error('is longer than %d characters !', MAX_LENGTH);
       isValid = false;
     }

--- a/index.test.js
+++ b/index.test.js
@@ -62,6 +62,7 @@ describe('validate-commit-msg.js', function() {
       expect(logs).to.deep.equal([msg]);
     });
 
+
     it('should work fine with a bigger body', function() {
       var message = [
         'chore(build): something',
@@ -117,11 +118,6 @@ describe('validate-commit-msg.js', function() {
     });
 
 
-    it('should not allow msg prefixed with "fixup!"', function() {
-      expect(m.validateMessage('fixup! fix($compile): something')).to.equal(INVALID);
-    });
-
-
     it('should handle undefined message"', function() {
       expect(m.validateMessage()).to.equal(INVALID);
     });
@@ -129,6 +125,12 @@ describe('validate-commit-msg.js', function() {
 
     it('should allow semver style commits', function() {
       expect(m.validateMessage('v1.0.0-alpha.1')).to.equal(VALID);
+    });
+
+
+    it('should allow fixup! and squash! commits', function() {
+      expect(m.validateMessage('fixup! fix($compile): something')).to.equal(VALID);
+      expect(m.validateMessage('squash! fix($compile): something super mega extra giga tera long, maybe even longer and longer and longer...')).to.equal(VALID);
     });
   });
 


### PR DESCRIPTION
`fixup!` and `squash!` are part of Git, commits tagged with them are not intended to be merged :

- http://fle.github.io/git-tip-keep-your-branch-clean-with-fixup-and-autosquash.html
- https://git-scm.com/docs/git-commit

```
$ (dev) git commit -m "Feature A is done"
[dev fb2f677] Feature A is done

$ (dev) git commit -m "Feature B is done"
[dev 733e2ff] Feature B is done

# you've removed a pdb : shameful commit
$ (dev) git commit --fixup fb2f677
[dev c5069d5] fixup! Feature A is done
```
```
$ (dev) git log --oneline
c5069d5 fixup! Feature A is done
733e2ff Feature B is done
fb2f677 Feature A is done
ac5db87 Previous commit
```
```
$ (dev) git rebase -i --autosquash ac5db87
ff4de2a Feature B is done
5478cee Feature A is done
ac5db87 Previous commit
```


If we do not want to allow fixup/squash (this is not in the Angular commit spec, after all), the way to use this feature is to ignore validation on the squash/fixup commit (`git commit --fixup --no-verify`).
I am not in favor to make this a habit, hence the PR :-)