### PR TITLE
feat(config): add helpMessage config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ You can specify options in `package.json`
     "validate-commit-msg": {
       "types": ["feat", "fix", "docs", "style", "refactor", "perf", "test", "chore", "revert"], // default
       "warnOnFail": false, // default
-      "maxSubjectLength": 100 // default
+      "maxSubjectLength": 100, // default
+      "helpMessage": "" //default
     }
   }
 }
@@ -48,6 +49,10 @@ If this is set to `true` errors will be logged to the console, however the commi
 
 This will control the maximum length of the subject.
 
+#### helpMessage
+
+If provided, the helpMessage string is displayed when a commit message is not valid. This allows projects to provide a better developer experience for new contributors.
+
 ### Other notes
 
 If the commit message begins with `WIP` then none of the validation will happen.
@@ -57,4 +62,3 @@ If the commit message begins with `WIP` then none of the validation will happen.
 
 This was originally developed by contributors to [the angular.js project](https://github.com/angular/angular.js). I
 pulled it out so I could re-use this same kind of thing in other projects.
-

--- a/index.js
+++ b/index.js
@@ -76,9 +76,14 @@ var validateMessage = function(message) {
 
   isValid = isValid || config.warnOnFail;
 
-  // Display original message when it is not valid, otherwise it will be lost
-  if (!isValid && message) {
-    console.log(message);
+  if(!isValid){
+    if(message){
+      // Display original message when it is not valid, otherwise it will be lost
+      console.log(message);
+    }
+    if(config.helpMessage) {
+      console.log(config.helpMessage);
+    }
   }
 
   return isValid;
@@ -87,6 +92,7 @@ var validateMessage = function(message) {
 
 // publish for testing
 exports.validateMessage = validateMessage;
+exports.config = config;
 
 // hacky start if not run by mocha :-D
 // istanbul ignore next

--- a/index.test.js
+++ b/index.test.js
@@ -12,6 +12,9 @@ describe('validate-commit-msg.js', function() {
   var VALID = true;
   var INVALID = false;
 
+  // modify project config for testing
+  m.config.helpMessage = undefined;
+
   beforeEach(function() {
     errors.length = 0;
     logs.length = 0;
@@ -85,6 +88,15 @@ describe('validate-commit-msg.js', function() {
       expect(m.validateMessage(msg)).to.equal(INVALID);
       expect(errors).to.deep.equal(['INVALID COMMIT MSG: does not match "<type>(<scope>): <subject>" !']);
       expect(logs).to.deep.equal([msg]);
+    });
+
+    it('should log the helpMessage on invalid commit messages', function() {
+      var msg = 'invalid message';
+      m.config.helpMessage = '\nPlease fix your commit message (and consider using http://npm.im/commitizen)\n';
+      expect(m.validateMessage(msg)).to.equal(INVALID);
+      expect(errors).to.deep.equal(['INVALID COMMIT MSG: does not match "<type>(<scope>): <subject>" !']);
+      expect(logs).to.deep.equal([msg, m.config.helpMessage]);
+      m.config.helpMessage = undefined;
     });
 
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
       "path": "node_modules/cz-conventional-changelog"
     },
     "validate-commit-msg": {
+      "helpMessage": "\nPlease fix your commit message (and consider using http://npm.im/commitizen)\n",
       "types": [
         "feat",
         "fix",


### PR DESCRIPTION
If provided, the helpMessage string is displayed when a commit message is not valid. This allows
projects to provide a better developer experience for new contributors.