### PR TITLE
feat: support %s interpolate in helpMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This will control the maximum length of the subject.
 
 If provided, the helpMessage string is displayed when a commit message is not valid. This allows projects to provide a better developer experience for new contributors.
 
+The `helpMessage` also supports interpoling a single `%s` with the original commit message.
+
 ### Other notes
 
 If the commit message begins with `WIP` then none of the validation will happen.

--- a/index.js
+++ b/index.js
@@ -76,17 +76,23 @@ var validateMessage = function(message) {
 
   isValid = isValid || config.warnOnFail;
 
-  if(!isValid){
-    if(message){
-      // Display original message when it is not valid, otherwise it will be lost
-      console.log(message);
-    }
-    if(config.helpMessage) {
-      console.log(config.helpMessage);
-    }
+  if (isValid) { // exit early and skip messaging logics
+    return true;
   }
 
-  return isValid;
+  var argInHelp = config.helpMessage && config.helpMessage.indexOf('%s') !== -1;
+
+  if (argInHelp) {
+    console.log(config.helpMessage, message);
+  } else if (message) {
+    console.log(message);
+  }
+
+  if (!argInHelp && config.helpMessage) {
+    console.log(config.helpMessage);
+  }
+
+  return false;
 };
 
 


### PR DESCRIPTION
This change supports using `%s` in the config.helpMessage, and if the %s is included, then the default message isn't printed since it'll be put into the output of the help message.