### PR TITLE
Support empty commits

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,16 @@ var error = function() {
 };
 
 
-var validateMessage = function(message) {
+var validateMessage = function(raw) {
+  var message = (raw || '').split('\n').filter(function (str) {
+    return str.indexOf('#') !== 0;
+  }).join('\n');
+
+  if (message === '') {
+    console.log('Aborting commit due to empty commit message.');
+    return false;
+  }
+
   var isValid = true;
 
   if (IGNORED.test(message)) {

--- a/index.test.js
+++ b/index.test.js
@@ -142,6 +142,11 @@ describe('validate-commit-msg.js', function() {
       expect(logs).to.not.deep.equal([]);
     });
 
+    it('should allow for empty commits', function() {
+      expect(m.validateMessage('# this is just a comment')).to.equal(INVALID);
+      expect(logs).to.deep.equal(['Aborting commit due to empty commit message.']);
+    });
+
 
     it('should handle undefined message"', function() {
       expect(m.validateMessage()).to.equal(INVALID);


### PR DESCRIPTION
Empty commits should abort the commit, but the validation still fails:

<img width="743" alt="screen shot 2016-03-06 at 08 27 21" src="https://cloud.githubusercontent.com/assets/13700/13553116/4f60ac72-e375-11e5-9ade-8379e471e915.png">

This change strips comments from the commit before verification and then if the message is actually empty, it'll abort the commit (with the same default git message):

<img width="484" alt="screen shot 2016-03-06 at 08 28 26" src="https://cloud.githubusercontent.com/assets/13700/13553120/6fcbed64-e375-11e5-83d8-7203f1fe5b30.png">
