### PR TITLE
fix(.git-location) : Handles case where .git is a file instead of dir…

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ exports.config = config;
 // istanbul ignore next
 if (process.argv.join('').indexOf('mocha') === -1) {
 
-  var commitMsgFile = process.argv[2] || './.git/COMMIT_EDITMSG';
+  var commitMsgFile = process.argv[2] || getGitFolder() + '/COMMIT_EDITMSG';
   var incorrectLogFile = commitMsgFile.replace('COMMIT_EDITMSG', 'logs/incorrect-commit-msgs');
 
   var hasToString = function hasToString(x) {
@@ -146,4 +146,23 @@ function getConfig() {
   var pkgFile = findup.sync(process.cwd(), 'package.json');
   var pkg = JSON.parse(fs.readFileSync(resolve(pkgFile, 'package.json')));
   return pkg && pkg.config && pkg.config['validate-commit-msg'] || {};
+}
+
+function getGitFolder()
+{
+  var gitDirLocation = './.git';
+  if (!fs.existsSync(gitDirLocation)) {
+      throw new Error('Cannot find file ' + gitDirLocation);
+  }
+
+  if(!fs.lstatSync(gitDirLocation).isDirectory()) {
+     var unparsedText = '' + fs.readFileSync(gitDirLocation);
+     gitDirLocation = unparsedText.substring('gitdir: '.length).trim();
+  }
+
+  if (!fs.existsSync(gitDirLocation)) {
+    throw new Error('Cannot find file ' + gitDirLocation);
+  }
+
+  return gitDirLocation;
 }

--- a/index.js
+++ b/index.js
@@ -112,6 +112,7 @@ var validateMessage = function(raw) {
 
 // publish for testing
 exports.validateMessage = validateMessage;
+exports.getGitFolder = getGitFolder;
 exports.config = config;
 
 // hacky start if not run by mocha :-D

--- a/index.test.js
+++ b/index.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var expect = require('chai').expect;
+var fs = require('fs');
 var sinon = require('sinon');
 var m = require('./index');
 var format = require('util').format;
@@ -170,8 +171,106 @@ describe('validate-commit-msg.js', function() {
     });
   });
 
+  describe('handle .git as folder', function()
+  {
+    before(function() {
+      sinon.stub(fs, "existsSync", function() {
+        return true;
+      });
+      sinon.stub(fs, "lstatSync", function() {
+        return {
+          isDirectory : function() { return true; }
+        }
+      });
+    });
+
+    it('should return ./.git when .git is a directory', function()
+    {
+      expect(m.getGitFolder()).to.be.equal('./.git');
+    });
+
+    after(function() {
+      fs.existsSync.restore();
+      fs.lstatSync.restore();
+    });
+  });
+
+  describe('handle .git as file', function()
+  {
+    before(function() {
+      sinon.stub(fs, "existsSync", function() {
+        return true;
+      });
+      sinon.stub(fs, "lstatSync", function(location) {
+        //Ensure that we say ./.git is a file, but ../../actual-folder is folder
+        return {
+          isDirectory : function() { return location != './.git'; }
+        }
+      });
+      sinon.stub(fs, 'readFileSync', function() {
+        return 'gitdir: ../../actual-folder';
+      });
+    });
+
+    it('should load gitdir from .git file', function() {
+      expect(m.getGitFolder()).to.be.equal('../../actual-folder');
+    });
+
+    after(function() {
+      fs.existsSync.restore();
+      fs.lstatSync.restore();
+      fs.readFileSync.restore();
+    });
+  });
+
+  describe('handle .git does not exist', function() {
+    before(function() {
+      sinon.stub(fs, "existsSync", function() {
+        return false;
+      })
+    });
+
+    it('should throw error when ./.git is missing', function() {
+        expect(m.getGitFolder).to.throw('Cannot find file ./.git');
+    });
+
+    after(function() {
+      fs.existsSync.restore();
+    });
+  });
+
+  describe('handle .git gitdir: folder does not exist', function() {
+    before(function() {
+      sinon.stub(fs, "existsSync", function(dir) {
+        return './.git' == dir;
+      });
+      sinon.stub(fs, "lstatSync", function(location) {
+        //Ensure that we say ./.git is a file, but ../../actual-folder is folder
+        return {
+          isDirectory : function() { return location != './.git'; }
+        }
+      });
+      sinon.stub(fs, 'readFileSync', function() {
+        return 'gitdir: ../../actual-folder';
+      })
+    });
+
+    it('should throw error when ./.git is missing', function() {
+      expect(m.getGitFolder).to.throw('Cannot find file ../../actual-folder');
+    });
+
+    after(function() {
+      fs.existsSync.restore();
+      fs.lstatSync.restore();
+      fs.readFileSync.restore();
+    });
+  });
+
+
   afterEach(function() {
     console.log = originalLog;
     console.error = originalError;
   });
+
+
 });


### PR DESCRIPTION
When using git submodules, the .git folder is actually a file containing a property that tells us where we should be looking for the files that are usually in the .git folder.

We can use the contents of that file to find where the COMMIT_EDITMSG is actually located.