### PR TITLE
feat(subjectPattern): add simple subject validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ You can specify options in `package.json`
       "types": ["feat", "fix", "docs", "style", "refactor", "perf", "test", "chore", "revert"], // default
       "warnOnFail": false, // default
       "maxSubjectLength": 100, // default
-      "helpMessage": "" //default
+      "helpMessage": "", //default
+      "subjectPattern": /.+/, // default
+      "subjectPatternErrorMsg": 'subject pattern does not match "%s"' // default
     }
   }
 }
@@ -54,6 +56,21 @@ This will control the maximum length of the subject.
 If provided, the helpMessage string is displayed when a commit message is not valid. This allows projects to provide a better developer experience for new contributors.
 
 The `helpMessage` also supports interpoling a single `%s` with the original commit message.
+
+#### subjectPattern
+
+Optional, accepts a RegExp to match the commit message subject against.
+
+#### subjectPatternErrorMsg
+
+If `subjectPattern` is provided, this message will be displayed if the commit message subject does not match the pattern. Placeholder `%s` can be used to include `subjectPattern` in the message (can be used one time only):
+
+```
+subjectPatternErrorMsg: 'the pattern is %s, but I cannot use %s twice'
+
+// Will print:
+// the pattern is /.+/, but I cannot use %s twice
+```
 
 ### Other notes
 

--- a/index.js
+++ b/index.js
@@ -67,6 +67,9 @@ var validateMessage = function(raw) {
     var scope = match[4];
     var subject = match[5];
 
+    var SUBJECT_PATTERN = config.subjectPattern || /.+/;
+    var SUBJECT_PATTERN_ERROR_MSG = config.subjectPatternErrorMsg || 'subject does not match pattern "%s"';
+
     if (firstLine.length > MAX_LENGTH && !squashing) {
       error('is longer than %d characters !', MAX_LENGTH);
       isValid = false;
@@ -74,6 +77,11 @@ var validateMessage = function(raw) {
 
     if (TYPES !== '*' && TYPES.indexOf(type) === -1) {
       error('"%s" is not allowed type !', type);
+      isValid = false;
+    }
+
+    if (!SUBJECT_PATTERN.exec(subject)) {
+      error(SUBJECT_PATTERN_ERROR_MSG, SUBJECT_PATTERN.toString());
       isValid = false;
     }
   }

--- a/index.test.js
+++ b/index.test.js
@@ -169,6 +169,18 @@ describe('validate-commit-msg.js', function() {
       expect(m.validateMessage('Merge branch master into validate-commit-msg-integration')).to.equal(INVALID);
       expect(m.validateMessage('Merge branch \'master\' into validate-commit_msg-integration')).to.equal(VALID);
     });
+
+    it('should validate subject against subjectPattern if provided', function() {
+      var msg = 'chore(build): A something Z';
+      m.config.subjectPattern = /^A.*Z$/;
+      expect(m.validateMessage(msg)).to.equal(VALID);
+
+      msg = 'chore(build): something';
+      expect(m.validateMessage(msg)).to.equal(INVALID);
+
+      expect(errors).to.deep.equal(['INVALID COMMIT MSG: subject does not match pattern "/^A.*Z$/"']);
+      expect(logs).to.deep.equal([msg]);
+    });
   });
 
   describe('handle .git as folder', function()


### PR DESCRIPTION
Provide the following config options to support simple subject validation:

subjectPattern: A regex to match the subject against.
subjectPatternErrorMsg: A custom error message for subject pattern mismatches.