### PR TITLE
feat(helpMessage): print the entire message when using the %s placeholder

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,9 +34,11 @@ var error = function() {
 
 
 var validateMessage = function(raw) {
-  var message = (raw || '').split('\n').filter(function (str) {
+  var messageWithBody = (raw || '').split('\n').filter(function (str) {
     return str.indexOf('#') !== 0;
   }).join('\n');
+
+  var message = messageWithBody.split('\n').shift();
 
   if (message === '') {
     console.log('Aborting commit due to empty commit message.');
@@ -105,7 +107,7 @@ var validateMessage = function(raw) {
   var argInHelp = config.helpMessage && config.helpMessage.indexOf('%s') !== -1;
 
   if (argInHelp) {
-    console.log(config.helpMessage, message);
+    console.log(config.helpMessage, messageWithBody);
   } else if (message) {
     console.log(message);
   }
@@ -135,7 +137,7 @@ if (process.argv.join('').indexOf('mocha') === -1) {
   };
 
   fs.readFile(commitMsgFile, function(err, buffer) {
-    var msg = firstLineFromBuffer(buffer);
+    var msg = getCommitMessage(buffer);
 
     if (!validateMessage(msg)) {
       fs.appendFile(incorrectLogFile, msg + '\n', function() {
@@ -145,8 +147,8 @@ if (process.argv.join('').indexOf('mocha') === -1) {
       process.exit(0);
     }
 
-    function firstLineFromBuffer(buffer) {
-      return hasToString(buffer) && buffer.toString().split('\n').shift();
+    function getCommitMessage(buffer) {
+      return hasToString(buffer) && buffer.toString();
     }
   });
 }

--- a/index.test.js
+++ b/index.test.js
@@ -103,6 +103,17 @@ describe('validate-commit-msg.js', function() {
       m.config.helpMessage = undefined;
     });
 
+    it('should show the entire body when using the %s placeholder', function() {
+      var message = [
+        'some header',
+        '', // BLANK_LINE
+        'Elaborated body'
+      ].join('\n');
+      m.config.helpMessage = '%s';
+      expect(m.validateMessage(message)).to.equal(INVALID);
+      expect(logs).to.deep.equal([message]);
+    });
+
     it('should interpolate message into helpMessage', function() {
       var msg = 'invalid message';
       m.config.helpMessage = '\nPlease fix your %s\n';


### PR DESCRIPTION
Add capability for #32. This will avoid people from lose their long commit message on failures when using the `%s` placeholder.