### PR TITLE
fix(lib): Reduced merge check strictness

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var TYPES = config.types || ['feat', 'fix', 'docs', 'style', 'refactor', 'perf',
 
 // fixup! and squash! are part of Git, commits tagged with them are not intended to be merged, cf. https://git-scm.com/docs/git-commit
 var PATTERN = /^((fixup! |squash! )?(\w+)(?:\(([^\)\s]+)\))?: (.+))(?:\n|$)/;
-var MERGE_COMMIT_PATTERN = /^Merge branch \'.*\' into .*$/;
+var MERGE_COMMIT_PATTERN = /^Merge branch \'.*\' .*$/;
 var error = function() {
   // gitx does not display it
   // http://gitx.lighthouseapp.com/projects/17830/tickets/294-feature-display-hook-error-message-when-hook-fails

--- a/index.test.js
+++ b/index.test.js
@@ -179,6 +179,7 @@ describe('validate-commit-msg.js', function() {
       expect(m.validateMessage('Merge branch \'master\' into validate-commit-msg-integration')).to.equal(VALID);
       expect(m.validateMessage('Merge branch master into validate-commit-msg-integration')).to.equal(INVALID);
       expect(m.validateMessage('Merge branch \'master\' into validate-commit_msg-integration')).to.equal(VALID);
+      expect(m.validateMessage('Merge branch \'master\' of')).to.equal(VALID);
     });
 
     it('should validate subject against subjectPattern if provided', function() {


### PR DESCRIPTION
The merge message check is too strict. It fails auto merge commit messages because they don't
include the word into