### PR TITLE
fix(lib): make merge commit regex even less strict (fix #35)

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var TYPES = config.types || ['feat', 'fix', 'docs', 'style', 'refactor', 'perf',
 
 // fixup! and squash! are part of Git, commits tagged with them are not intended to be merged, cf. https://git-scm.com/docs/git-commit
 var PATTERN = /^((fixup! |squash! )?(\w+)(?:\(([^\)\s]+)\))?: (.+))(?:\n|$)/;
-var MERGE_COMMIT_PATTERN = /^Merge branch \'.*\' .*$/;
+var MERGE_COMMIT_PATTERN = /^Merge /;
 var error = function() {
   // gitx does not display it
   // http://gitx.lighthouseapp.com/projects/17830/tickets/294-feature-display-hook-error-message-when-hook-fails

--- a/index.test.js
+++ b/index.test.js
@@ -177,9 +177,11 @@ describe('validate-commit-msg.js', function() {
 
     it('should handle merge commits', function() {
       expect(m.validateMessage('Merge branch \'master\' into validate-commit-msg-integration')).to.equal(VALID);
-      expect(m.validateMessage('Merge branch master into validate-commit-msg-integration')).to.equal(INVALID);
+      expect(m.validateMessage('Merge branch master into validate-commit-msg-integration')).to.equal(VALID);
       expect(m.validateMessage('Merge branch \'master\' into validate-commit_msg-integration')).to.equal(VALID);
       expect(m.validateMessage('Merge branch \'master\' of')).to.equal(VALID);
+      expect(m.validateMessage('Merge remote-tracking branch \'master\' into validate-commit-msg-integration')).to.equal(VALID);
+      expect(m.validateMessage('Merge something from somewhere to everywhere :)')).to.equal(VALID);
     });
 
     it('should validate subject against subjectPattern if provided', function() {


### PR DESCRIPTION
From the git source [1] we can see that the only part that git generates for sure in the merge commit message is the
prefix `Merge `. This commit reduces the strictness of the merge detection to only that. While this might allow false
postives, I consider these better than false negatives (where committing is disallowed and people have to use
`--no-verify`).

[1]: https://github.com/git/git/blob/master/builtin/fmt-merge-msg.c#L418