### PR TITLE
feat(helpMessage): show valid types when invalid type was used

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var semverRegex = require('semver-regex')
 var config = getConfig();
 var MAX_LENGTH = config.maxSubjectLength || 100;
 var IGNORED = new RegExp(util.format('(^WIP)|(^%s$)', semverRegex().source));
-var TYPES = config.types || ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'chore', 'revert'];
+var TYPES = config.types = config.types || ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'chore', 'revert'];
 
 // fixup! and squash! are part of Git, commits tagged with them are not intended to be merged, cf. https://git-scm.com/docs/git-commit
 var PATTERN = /^((fixup! |squash! )?(\w+)(?:\(([^\)\s]+)\))?: (.+))(?:\n|$)/;
@@ -78,7 +78,7 @@ var validateMessage = function(raw) {
     }
 
     if (TYPES !== '*' && TYPES.indexOf(type) === -1) {
-      error('"%s" is not allowed type !', type);
+      error('"%s" is not allowed type ! Valid types are: %s', type, config.types.join(', '));
       isValid = false;
     }
 

--- a/index.test.js
+++ b/index.test.js
@@ -129,10 +129,9 @@ describe('validate-commit-msg.js', function() {
       var msg = 'weird($filter): something';
 
       expect(m.validateMessage(msg)).to.equal(INVALID);
-      expect(errors).to.deep.equal(['INVALID COMMIT MSG: "weird" is not allowed type !']);
+      expect(errors[0]).to.equal('INVALID COMMIT MSG: "weird" is not allowed type ! Valid types are: ' + m.config.types.join(', '));
       expect(logs).to.deep.equal([msg]);
     });
-
 
     it('should allow empty scope', function() {
       expect(m.validateMessage('fix: blablabla')).to.equal(VALID);


### PR DESCRIPTION
I'm always forgetting the list of custom types or the exact wording of the type, so here's a little something to show them if you got the type wrong.

```
13:12 jzetlen@work $ g acm "doc: whoops, forgot the 's' on 'docs'"

INVALID COMMIT MSG: "doc" is not allowed type ! Valid types are: feat, fix, docs, style, refactor, perf, test, chore, revert, tech
doc: whoops, forgot the 's' on 'docs'
```

