### PR TITLE
chore: reduce tarball size

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
   "dependencies": {
     "findup": "0.1.5",
     "semver-regex": "1.0.0"
-  }
+  },
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
Only `index.js` is necessary at runtime; the installed package is already small, but what the hey :)