### PR TITLE
refactor(index): fetch commit-types from module

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@
 'use strict';
 
 var fs = require('fs');
+var conventionalCommitTypes = require('conventional-commit-types');
 var util = require('util');
 var resolve = require('path').resolve;
 var findup = require('findup');
@@ -33,7 +34,7 @@ var error = function() {
 
 
 var validateMessage = function(raw) {
-  var types = config.types = config.types || ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'chore', 'revert'];
+  var types = config.types = config.types || conventionalCommitTypes;
 
   // resolve types from a module
   if (typeof types === 'string' && types !== '*') {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "chai": "3.4.1",
     "codecov.io": "0.1.6",
     "commitizen": "2.5.0",
-    "conventional-commit-types": "^2.0.0",
     "cz-conventional-changelog": "1.1.5",
     "ghooks": "1.0.3",
     "istanbul": "0.4.2",
@@ -69,6 +68,7 @@
     }
   },
   "dependencies": {
+    "conventional-commit-types": "^2.0.0",
     "findup": "0.1.5",
     "semver-regex": "1.0.0"
   },


### PR DESCRIPTION
This PR fixes #43 

I had issues testing this code change because the config types were passed in from the _package.json_ so it was not getting to _commit-types_ from the module. 

A solution I thought was deleting the _types_ field from the _package.json_. Another was cloning the _package.json_, deleting the _types_ field and replace it after. Felt like too much effort, not sure it was worth it.

Suggestions are welcome on how to test it, if it's worth it.