### PR TITLE
fix: use default commit types

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var fs = require('fs');
-var conventionalCommitTypes = require('conventional-commit-types');
 var util = require('util');
 var resolve = require('path').resolve;
 var findup = require('findup');
@@ -34,7 +33,7 @@ var error = function() {
 
 
 var validateMessage = function(raw) {
-  var types = config.types = config.types || conventionalCommitTypes;
+  var types = config.types = config.types || 'conventional-commit-types';
 
   // resolve types from a module
   if (typeof types === 'string' && types !== '*') {


### PR DESCRIPTION
I'm currently getting this thrown when I try and commit anything to my modules:

```
/Users/mattlewis/Code/open-source/angular2-calendar/node_modules/validate-commit-msg/index.js:87
    if (types !== '*' && types.indexOf(type) === -1) {
                               ^

TypeError: types.indexOf is not a function
    at validateMessage (/Users/mattlewis/Code/open-source/angular2-calendar/node_modules/validate-commit-msg/index.js:87:32)
    at /Users/mattlewis/Code/open-source/angular2-calendar/node_modules/validate-commit-msg/index.js:149:10
```

This should do the trick, happy to follow up with a test, just wanted to get something out the door as I'm currently unable to commit to any of my modules 😄 