### PR TITLE
docs(README): Clarify usage with husky

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Tweet][twitter-badge]][twitter]
 
 This provides you a binary that you can use as a githook to validate the commit message. I recommend
-[husky](http://npm.im/husky). You'll want to make this part of the `commit-msg` githook.
+[husky](http://npm.im/husky). You'll want to make this part of the `commit-msg` githook, e.g. when using [husky](http://npm.im/husky), add `"commitmsg": "validate-commit-msg"` to your [npm scripts](https://docs.npmjs.com/misc/scripts) in `package.json`).
 
 Validates that your commit message follows this format:
 


### PR DESCRIPTION
As someone who wasn't familiar with how husky worked, I had to dig through the docs a little bit to figure out that "commit-msg" wasn't a valid script. I figured it would be much better to be completely explicit about how to set it up, so people can just copy-and-paste for the recommended setup.