### PR TITLE
refactor(cli-validation): separate cli behaviour from validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,3 @@
-#!/usr/bin/env node
-
-/**
- * Git COMMIT-MSG hook for validating commit message
- * See https://docs.google.com/document/d/1rk04jEuGfk9kYzfqCuOlPTSJw3hEDZJTBN5E5f1SALo/edit
- *
- * Installation:
- * >> cd <angular-repo>
- * >> ln -s ../../validate-commit-msg.js .git/hooks/commit-msg
- */
-
 'use strict';
 
 var fs = require('fs');
@@ -132,39 +121,10 @@ var validateMessage = function(raw) {
   return false;
 };
 
-
 // publish for testing
 exports.validateMessage = validateMessage;
 exports.getGitFolder = getGitFolder;
 exports.config = config;
-
-// hacky start if not run by mocha :-D
-// istanbul ignore next
-if (process.argv.join('').indexOf('mocha') === -1) {
-
-  var commitMsgFile = process.argv[2] || getGitFolder() + '/COMMIT_EDITMSG';
-  var incorrectLogFile = commitMsgFile.replace('COMMIT_EDITMSG', 'logs/incorrect-commit-msgs');
-
-  var hasToString = function hasToString(x) {
-    return x && typeof x.toString === 'function';
-  };
-
-  fs.readFile(commitMsgFile, function(err, buffer) {
-    var msg = getCommitMessage(buffer);
-
-    if (!validateMessage(msg)) {
-      fs.appendFile(incorrectLogFile, msg + '\n', function() {
-        process.exit(1);
-      });
-    } else {
-      process.exit(0);
-    }
-
-    function getCommitMessage(buffer) {
-      return hasToString(buffer) && buffer.toString();
-    }
-  });
-}
 
 function getConfig() {
   var pkgFile = findup.sync(process.cwd(), 'package.json');

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -12,13 +12,13 @@
 'use strict';
 
 var fs = require('fs');
-var validateMessage = require('../index').validateMessage;
+var index = require('../index');
 
 // hacky start if not run by mocha :-D
 // istanbul ignore next
 if (process.argv.join('').indexOf('mocha') === -1) {
 
-  var commitMsgFile = process.argv[2] || getGitFolder() + '/COMMIT_EDITMSG';
+  var commitMsgFile = process.argv[2] || index.getGitFolder() + '/COMMIT_EDITMSG';
   var incorrectLogFile = commitMsgFile.replace('COMMIT_EDITMSG', 'logs/incorrect-commit-msgs');
 
   var hasToString = function hasToString(x) {
@@ -28,7 +28,7 @@ if (process.argv.join('').indexOf('mocha') === -1) {
   fs.readFile(commitMsgFile, function(err, buffer) {
     var msg = getCommitMessage(buffer);
 
-    if (!validateMessage(msg)) {
+    if (!index.validateMessage(msg)) {
       fs.appendFile(incorrectLogFile, msg + '\n', function() {
         process.exit(1);
       });

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+/**
+ * Git COMMIT-MSG hook for validating commit message
+ * See https://docs.google.com/document/d/1rk04jEuGfk9kYzfqCuOlPTSJw3hEDZJTBN5E5f1SALo/edit
+ *
+ * Installation:
+ * >> cd <angular-repo>
+ * >> ln -s ../../validate-commit-msg.js .git/hooks/commit-msg
+ */
+
+'use strict';
+
+var fs = require('fs');
+var validateMessage = require('../index').validateMessage;
+
+// hacky start if not run by mocha :-D
+// istanbul ignore next
+if (process.argv.join('').indexOf('mocha') === -1) {
+
+  var commitMsgFile = process.argv[2] || getGitFolder() + '/COMMIT_EDITMSG';
+  var incorrectLogFile = commitMsgFile.replace('COMMIT_EDITMSG', 'logs/incorrect-commit-msgs');
+
+  var hasToString = function hasToString(x) {
+    return x && typeof x.toString === 'function';
+  };
+
+  fs.readFile(commitMsgFile, function(err, buffer) {
+    var msg = getCommitMessage(buffer);
+
+    if (!validateMessage(msg)) {
+      fs.appendFile(incorrectLogFile, msg + '\n', function() {
+        process.exit(1);
+      });
+    } else {
+      process.exit(0);
+    }
+
+    function getCommitMessage(buffer) {
+      return hasToString(buffer) && buffer.toString();
+    }
+  });
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "add-contributor": "all-contributors add",
     "generate-contributors": "all-contributors generate",
     "commit": "git-cz",
-    "commitmsg": "opt --in commitmsg --exec \"node ./index.js\"",
+    "commitmsg": "opt --in commitmsg --exec \"node ./lib/cli.js\"",
     "precommit": "opt --in precommit --exec \"npm run validate\"",
     "check-coverage": "istanbul check-coverage --statements 100 --branches 90 --functions 100 --lines 100",
     "report-coverage": "cat ./coverage/lcov.info | codecov",
@@ -17,7 +17,7 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "bin": {
-    "validate-commit-msg": "index.js"
+    "validate-commit-msg": "./lib/cli.js"
   },
   "repository": {
     "type": "git",
@@ -78,6 +78,7 @@
     "semver-regex": "1.0.0"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "lib/cli.js"
   ]
 }

--- a/wallaby.config.js
+++ b/wallaby.config.js
@@ -1,6 +1,6 @@
 module.exports = function() {
   return {
-    files: ['index.js', 'package.json'],
+    files: ['index.js', 'lib/**/*.js', 'package.json'],
     tests: ['index.test.js'],
     env: {
       type: 'node'


### PR DESCRIPTION
This separation will facilitate further refactoring, moving the main validation to lib, split in
multiple files etc.