### PR TITLE
fix(scope): Allow no scope in the commit message when validate is set to true.

### DIFF
--- a/lib/validateMessage.js
+++ b/lib/validateMessage.js
@@ -153,6 +153,11 @@ function validateScope(isValid, scope) {
       error('a scope is required !');
       isValid = false;
     }
+    // If scope is not provided, we ignore the rest of the testing and do early
+    // return here.
+    if (scopes.length === 0) {
+      return isValid;
+    }
     if (isValid && multipleScopesAllowed) {
       scopes.forEach(validateIndividualScope);
     }

--- a/test/validateMessage.test.js
+++ b/test/validateMessage.test.js
@@ -232,6 +232,19 @@ describe('validate-commit-msg.js', function() {
       m.config.scope = undefined;
     });
 
+    it('should allow no scope when only validate is set to true', function() {
+      var msg = 'chore: Publish';
+
+      m.config.scope = {
+        validate: true
+      };
+
+      expect(m.validateMessage(msg)).to.equal(VALID);
+      expect(logs).to.deep.equal([]);
+
+      m.config.scope = undefined;
+    });
+
     it('should allow empty scope', function() {
       expect(m.validateMessage('fix: blablabla')).to.equal(VALID);
       expect(errors).to.deep.equal([]);


### PR DESCRIPTION
When `validate: true`, it should allow the user provided no scope. Commit message such as `chore: Publish` should pass.

However, the current setup tries to call multiple method on `undefined` in that situation. So I fixed that by adding `scope.length > 0` before validate any individual message.  