### PR TITLE
Commit message not throwing error while commit from git gui

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -18,10 +18,11 @@ var getGitFolder = require('./getGitFolder');
 // hacky start if not run by mocha :-D
 // istanbul ignore next
 if (process.argv.join('').indexOf('mocha') === -1) {
-  var commitMsgFileOrText = process.argv[2] || getGitFolder(),
-  //GIT GUI stores commit msg @GITGUI_EDITMSG file, 
+  var commitMsgFileOrText,
+      gitFolder = getGitFolder() + '/',
+  //GIT GUI stores commit msg @GITGUI_EDITMSG file, so user can pass file name has argument 
   //if it doesn't exist then we are considering "/COMMIT_EDITMSG" file
-    filename = 'GITGUI_EDITMSG';
+    filename = (process.argv[2] && fs.existsSync(gitFolder  + process.argv[2])) ? process.argv[2] : 'COMMIT_EDITMSG';
 
   var bufferToString = function (buffer) {
     return hasToString(buffer) && buffer.toString();
@@ -31,7 +32,7 @@ if (process.argv.join('').indexOf('mocha') === -1) {
     return x && typeof x.toString === 'function';
   };
 
-  var validate = function (msg, isFile) {
+  var validate = function (msg, isFile, filename) {
     if (!validateMessage(msg)) {
       var incorrectLogFile = (
         isFile
@@ -47,12 +48,7 @@ if (process.argv.join('').indexOf('mocha') === -1) {
     }
   };
 
-  filename = (
-    fs.existsSync(commitMsgFileOrText + filename)
-    ? filename 
-    : 'COMMIT_EDITMSG'
-  );
-  commitMsgFileOrText += '/' + filename;
+  commitMsgFileOrText = gitFolder + filename;
 
   fs.readFile(commitMsgFileOrText, function readFile(err, buffer) {
     if(err && err.code !== 'ENOENT') {
@@ -66,6 +62,6 @@ if (process.argv.join('').indexOf('mocha') === -1) {
       : commitMsgFileOrText
     );
 
-    validate(msg, isFile);
+    validate(msg, isFile, filename);
   });
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -18,7 +18,10 @@ var getGitFolder = require('./getGitFolder');
 // hacky start if not run by mocha :-D
 // istanbul ignore next
 if (process.argv.join('').indexOf('mocha') === -1) {
-  var commitMsgFileOrText = process.argv[2] || getGitFolder() + '/COMMIT_EDITMSG';
+  var commitMsgFileOrText = process.argv[2] || getGitFolder(),
+  //GIT GUI stores commit msg @GITGUI_EDITMSG file, 
+  //if it doesn't exist then we are considering "/COMMIT_EDITMSG" file
+    filename = 'GITGUI_EDITMSG';
 
   var bufferToString = function (buffer) {
     return hasToString(buffer) && buffer.toString();
@@ -32,7 +35,7 @@ if (process.argv.join('').indexOf('mocha') === -1) {
     if (!validateMessage(msg)) {
       var incorrectLogFile = (
         isFile
-        ? commitMsgFileOrText.replace('COMMIT_EDITMSG', 'logs/incorrect-commit-msgs')
+        ? commitMsgFileOrText.replace(filename, 'logs/incorrect-commit-msgs')
         : (getGitFolder() + '/logs/incorrect-commit-msgs')
       );
 
@@ -43,6 +46,13 @@ if (process.argv.join('').indexOf('mocha') === -1) {
       process.exit(0);
     }
   };
+
+  filename = (
+    fs.existsSync(commitMsgFileOrText + filename)
+    ? filename 
+    : 'COMMIT_EDITMSG'
+  );
+  commitMsgFileOrText += '/' + filename;
 
   fs.readFile(commitMsgFileOrText, function readFile(err, buffer) {
     if(err && err.code !== 'ENOENT') {


### PR DESCRIPTION
Analysis: [cli.js](https://github.com/kentcdodds/validate-commit-msg/blob/master/lib/cli.js) is looking for the commit message from `git/COMMIT_EDITMSG` file irrespective of mode of committing the code (GIT BASH or GIT GUI or GITHUB)
GIT GUI will be storing the commit message in `.git/GITGUI_EDITMSG` file and we are [reading](https://github.com/kentcdodds/validate-commit-msg/blob/master/lib/cli.js#L47) from  `COMMIT_EDITMSG` file always for the commit message which is causing the issue.

Solution: Checking for the existance of `GITGUI_EDITMSG` file, if it is there then we are taking the commit message from that file else we are reading the message from `COMMIT_EDITMSG`. As `GITGUI_EDITMSG` will be created and deleted only when we are commiting from GIT GUI.
