### PR TITLE
refactor(cli): split the 2 big functions into small ones

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,86 +17,76 @@
 'use strict';
 
 var fs = require('fs');
+var path = require('path');
 
 var getGitFolder = require('./getGitFolder');
 var validateMessage = require('../index');
 
-// hacky start if not run by mocha :-D
-// istanbul ignore next
-if (process.argv.join('').indexOf('mocha') === -1) {
-  var bufferToString = function (buffer) {
-    var hasToString = buffer && typeof buffer.toString === 'function';
-    return hasToString && buffer.toString();
-  };
+var commitMsgFileOrText = process.argv[2];
+var commitErrorLogPath = process.argv[3];
 
-  var getFileContent = function (filePath) {
-    try {
-      var buffer = fs.readFileSync(filePath);
-      return bufferToString(buffer);
-    } catch (err) {
-      // Ignore these error types because is most likely it is validating
-      // a commit from a text instead of a file
-      if(err && err.code !== 'ENOENT' && err.code !== 'ENAMETOOLONG') {
-        throw err;
-      }
-    }
-  };
+// On running the validation over a text instead of git files such as COMMIT_EDITMSG and GITGUI_EDITMSG
+// is possible to be doing that the from anywhere. Therefore the git directory might not be available.
+var gitDirectory;
+try {
+  gitDirectory = getGitFolder();
 
-  var getCommit = function() {
-    var file;
-    var fileContent;
-    var gitDirectory;
+  if (!commitErrorLogPath) {
+    commitErrorLogPath = path.resolve(gitDirectory, 'logs/incorrect-commit-msgs');
+  }
+} catch (err) {}
 
-    var commitMsgFileOrText = process.argv[2];
-    var commitErrorLogPath = process.argv[3];
+var bufferToString = function (buffer) {
+  var hasToString = buffer && typeof buffer.toString === 'function';
 
-    var commit = {
-      // if it is running from git directory or for a file from there
-      // these info might change ahead
-      message: commitMsgFileOrText,
-      errorLog: commitErrorLogPath || null,
-      file: null,
-    };
-
-    // On running the validation over a text instead of git files such as COMMIT_EDITMSG and GITGUI_EDITMSG
-    // is possible to be doing that the from anywhere. Therefore the git directory might not be available.
-    try {
-      gitDirectory = getGitFolder();
-
-      // Try to load commit from a path passed as argument
-      if (commitMsgFileOrText) {
-        file = gitDirectory + '/' + commitMsgFileOrText;
-        fileContent = getFileContent(file);
-      }
-
-      // If no file or message is available then try to load it from the default commit file
-      if (!fileContent && !commitMsgFileOrText) {
-        file = gitDirectory + '/COMMIT_EDITMSG';
-        fileContent = getFileContent(file);
-      }
-
-      // Could resolve the content from a file
-      if (fileContent) {
-        commit.file = file;
-        commit.message = fileContent;
-      }
-
-      // Default error log path
-      if (!commit.errorLog) {
-        commit.errorLog = gitDirectory + '/logs/incorrect-commit-msgs';
-      }
-    } catch (err) {}
-
-    return commit;
-  };
-
-  var validate = function (commit) {
-    if (!validateMessage(commit.message, commit.file) && commit.errorLog) {
-      fs.appendFileSync(commit.errorLog, commit.message + '\n');
-      process.exit(1);
-    } else {
-      process.exit(0);
-    }
-  };
-  validate(getCommit());
+  return hasToString && buffer.toString();
 }
+
+var getCommit = function (msgFileOrText) {
+  if (msgFileOrText !== undefined) {
+    return getCommitFromFile(msgFileOrText) || { message: msgFileOrText };
+  }
+
+  return getCommitFromFile('COMMIT_EDITMSG') || { message: null };
+}
+
+var getCommitFromFile = function (file) {
+  if (!gitDirectory || !file) {
+    return null;
+  }
+
+  file = path.resolve(gitDirectory, file);
+  var message = getFileContent(file);
+
+  return (!message) ? null : {
+    message: message,
+    sourceFile: file
+  };
+}
+
+var getFileContent = function (filePath) {
+  try {
+    var buffer = fs.readFileSync(filePath);
+
+    return bufferToString(buffer);
+  } catch (err) {
+    // Ignore these error types because it is most likely validating
+    // a commit from a text instead of a file
+    if (err && err.code !== 'ENOENT' && err.code !== 'ENAMETOOLONG') {
+      throw err;
+    }
+  }
+}
+
+var validate = function (msgFileOrText) {
+  var commit = getCommit(msgFileOrText);
+
+  if (!validateMessage(commit.message, commit.sourceFile) && commitErrorLogPath) {
+    fs.appendFileSync(commitErrorLogPath, commit.message + '\n');
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+validate(commitMsgFileOrText);


### PR DESCRIPTION
+ use `path.resolve()`
+ remove apparently useless? guard for Mocha