### PR TITLE
feat(config): add support for .vcmrc.js file

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,19 +2,31 @@
 
 var findup = require('findup');
 var fs = require('fs');
-var resolve = require('path').resolve;
+var path = require('path');
+var resolve = path.resolve;
 
 function getConfigObject(filename) {
   try {
-    var rcFile = findup.sync(process.cwd(), filename);
-    return JSON.parse(fs.readFileSync(resolve(rcFile, filename)));
+    var rcFileExtension = path.extname(filename);
+    var rcFileBasePath = findup.sync(process.cwd(), filename);
+    var rcFileFullPath = resolve(rcFileBasePath, filename);
+
+    switch(rcFileExtension) {
+      case '':
+      case '.json':
+        return JSON.parse(fs.readFileSync(rcFileFullPath));
+      case '.js':
+        return require(rcFileFullPath);
+      default:
+        return null;
+    }
   } catch (e) {
     return null;
   }
 }
 
 function getRcConfig() {
-  return getConfigObject('.vcmrc');
+  return getConfigObject('.vcmrc') || getConfigObject('.vcmrc.js');
 }
 
 function getPackageConfig() {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -70,6 +70,11 @@ describe('config', function() {
       expect(configObject.helpMessage).to.equal('fix your commit');
     });
 
+    it('returns config object given filename with .js extension', function() {
+      var configObject = config.getConfigObject('vcmrc-teststub.js');
+      expect(configObject.helpMessage).to.equal('fix commit please');
+    });
+
     it('returns null on error', function() {
       fs.readFileSync.restore();
       sinon.stub(fs, 'readFileSync', function() {

--- a/vcmrc-teststub.js
+++ b/vcmrc-teststub.js
@@ -1,0 +1,3 @@
+module.exports = {
+  helpMessage: 'fix commit please'
+};


### PR DESCRIPTION
# Summary

Allow support for `.vcmrc.js` so that users do not have to retype in `types` or other settings into the `.vcmrc` file. Instead, they can use javascript to build the config object and import their settings.

What do you think of this proposed feature?

###### I wrote a test to `require` the `.vcmrc.js` file but it crashes with `esprima`. I'm not sure what's happening. **Please help me write the test correctly**